### PR TITLE
fix: don't show sample button for NowPlaying without sample

### DIFF
--- a/src/pages/Spotify/providers/now-playing-provider.tsx
+++ b/src/pages/Spotify/providers/now-playing-provider.tsx
@@ -29,10 +29,13 @@ export function NowPlayingProvider(props: { children: JSX.Element }) {
   const refresh = async () => {
     const response = await API.getNowPlaying();
     if (track?.href === response?.href) return;
-    setTrack(response ?? undefined);
-    if (!response) return;
-    addSample(response.sample);
-    setShouldShow(true);
+    setTrack(response);
+    if (response) {
+      if (response.sample) addSample(response.sample);
+      setShouldShow(true);
+    } else {
+      setShouldShow(false);
+    }
   };
 
   useEffect(() => {

--- a/src/pages/Spotify/sections/NowPlaying.tsx
+++ b/src/pages/Spotify/sections/NowPlaying.tsx
@@ -31,12 +31,18 @@ export function NowPlaying() {
             >
               <Box sx={sx.image}>
                 <Image src={track.image} size='60mm'>
-                  <SampleButton
-                    sample={track.sample}
-                    show={isHovering}
-                    playIcon={VolumeOff}
-                    pauseIcon={VolumeUp}
-                  />
+                  {track.sample ? (
+                    <>
+                      <SampleButton
+                        sample={track.sample}
+                        show={isHovering}
+                        playIcon={VolumeOff}
+                        pauseIcon={VolumeUp}
+                      />
+                    </>
+                  ) : (
+                    <></>
+                  )}
                 </Image>
               </Box>
               <Stack sx={sx.container} direction='column'>

--- a/src/pages/Spotify/sections/RecentlyPlayed.tsx
+++ b/src/pages/Spotify/sections/RecentlyPlayed.tsx
@@ -28,7 +28,7 @@ export function RecentlyPlayed() {
       const response = await API.getRecentlyPlayed();
       setTracks(response);
       for (const track of response) {
-        addSample(track.sample);
+        if (track?.sample) addSample(track.sample);
       }
     };
     getTracks();

--- a/src/pages/Spotify/sections/TopTracks.tsx
+++ b/src/pages/Spotify/sections/TopTracks.tsx
@@ -26,7 +26,7 @@ export function TopTracks() {
       const response = await API.getTopTracks();
       setTracks(response);
       for (const track of response) {
-        addSample(track.sample);
+        if (track?.sample) addSample(track.sample);
       }
     };
     getTracks();

--- a/src/pages/Spotify/service/types.ts
+++ b/src/pages/Spotify/service/types.ts
@@ -2,7 +2,7 @@ export type TrackType = {
   title: string;
   artists: string[];
   image: string;
-  sample: string;
+  sample?: string;
   href: string;
   isExplicit: boolean;
   isLocal: boolean;


### PR DESCRIPTION
related to issue in `personal-api` where Spotify has deprecated the `preview_url`.